### PR TITLE
Updated IPython import in map.

### DIFF
--- a/thorns/util/maps.py
+++ b/thorns/util/maps.py
@@ -172,7 +172,12 @@ def _multiprocessing_map(func, iterable, cfg):
 
 def _ipython_map(func, iterable, cfg):
 
-    from IPython.parallel import Client
+    import IPython
+
+    if int(IPython.__version__.split('.')[0]) < 4:
+        from IPython.parallel import Client
+    else:
+        from ipyparallel import Client
 
     rc = Client()
     rc[:].clear()


### PR DESCRIPTION
In IPython 4.0 IPython.parallel was debricated and moved to ipyparallel