### PR TITLE
Fix waves

### DIFF
--- a/thorns/waves.py
+++ b/thorns/waves.py
@@ -168,8 +168,8 @@ def ramped_tone(
         s[0:len(ramp_signal)] = s[0:len(ramp_signal)] * ramp_signal
         s[-len(ramp_signal):] = s[-len(ramp_signal):] * ramp_signal[::-1]
 
-    pad_signal = np.zeros(pad * fs)
-    pre_signal = np.zeros(pre * fs)
+    pad_signal = np.zeros(int(pad * fs))
+    pre_signal = np.zeros(int(pre * fs))
     sound = np.concatenate((pre_signal, s, pad_signal))
 
     return sound

--- a/thorns/waves.py
+++ b/thorns/waves.py
@@ -122,7 +122,8 @@ def ramped_tone(
         pad=0,
         pre=0,
         ramp=2.5e-3,
-        dbspl=None
+        dbspl=None,
+        phase=0,
 ):
     """Generate ramped tone singal.
 
@@ -147,6 +148,8 @@ def ramped_tone(
         Amplitude of the tone in dB SPL.  If None (default), no
         scaling.  Scaling is done before ramping and appending the
         pad.
+    phase : float, optional
+        starting phase of the sine signal (default is 0)
 
 
     Returns
@@ -159,7 +162,7 @@ def ramped_tone(
     assert ramp < duration/2
 
     t = np.arange(0, duration, 1/fs)
-    s = np.sin(2 * np.pi * t * freq)
+    s = np.sin(2 * np.pi * t * freq + phase)
     if dbspl is not None:
         s = set_dbspl(s, dbspl)
 


### PR DESCRIPTION
Fixes a type bug in thorns.waves.ramped_tone (typecast to integer) and implements a option to select the starting phase of a tone which is important e.g to implement time differences