### PR TITLE
typecast in psth function

### DIFF
--- a/thorns/stats.py
+++ b/thorns/stats.py
@@ -36,7 +36,7 @@ def psth(spike_trains, bin_size, normalize=True, **kwargs):
     all_spikes = np.concatenate(tuple(spike_trains['spikes']))
 
     duration = get_duration(spike_trains)
-    nbins = np.ceil(duration / bin_size)
+    nbins = int(np.ceil(duration / bin_size))
 
     if nbins == 0:
         return None, None


### PR DESCRIPTION
np.ceil returns a float but input to np.histogram should be int
this results in "VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future"