### PR TITLE
Dependency on PyTables / tables 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,7 @@ dependencies first:
 - Numpy
 - Scipy
 - Pandas
+- PyTables / tables
 - Matplotlib
 
 - py-notify (optional, enables notifications)

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,5 @@ setup(
     ],
 
     platforms = ["Linux", "Windows", "FreeBSD"],
-    install_requires=["numpy", "pandas", "scipy"],
+    install_requires=["numpy", "pandas", "scipy", "tables"],
 )


### PR DESCRIPTION
Thanks for making thorns available. Great name for a spike train library, too. 

Just a minor thing, the dependency on Pytables / tables is currently not listed in the Installation section in the Readme. I took the liberty to fix this. Might save the next user 5 minutes trying to figure out what's going on. 